### PR TITLE
Downgrade packages to support 1.76

### DIFF
--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -47,6 +47,8 @@ spl-memo = { version = "5.0", path = "../../memo/program", features = [
 strum = "0.26"
 strum_macros = "0.26"
 tokio = "1.39"
+zerofrom = "=0.1.5"
+litemap = "=0.7.4"
 
 [dev-dependencies]
 solana-test-validator = "2.0.3"


### PR DESCRIPTION
This PR pins two packages which bumped their MSRV beyond 1.76. After this PR is merged, the function [`install_spl_token_cli`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/31ee1c6eae8148186cdb124c68f83aa3affc5d12/rust/sealevel/client/src/warp_route.rs#L730) will need to be updated to point to the new commit in order to re-enable Solana deployments.